### PR TITLE
Solved problem with tel-input in Frontend acf_form

### DIFF
--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -53,8 +53,10 @@
 		$telInput.on('blur', function(){
       if( $telInput.intlTelInput("isValidNumber") ){
         $telInput.intlTelInput("setNumber", $telInput.intlTelInput( 'getNumber' ) );
+        $telInput.prev('input[type="hidden"]').val($telInput.intlTelInput('getNumber'));
       } else { // Clear input if number is not valid
         $telInput.val('');
+        $telInput.prev('input[type="hidden"]').val('');
       }
     })
 		// Initialize Input	
@@ -79,5 +81,12 @@
 		acf.add_action('append_field/type=intl_tel_input', initialize_field);
 	
 	}
+
+    /**
+     * Apply the initialize_fields in Frontend acf_form
+     */
+    $('[data-type="intl_tel_input"]').each(function () {
+        initialize_field($(this));
+    });
 	
 })(jQuery);

--- a/fields/class-jony-acf-field-intl-tel-input-v5.php
+++ b/fields/class-jony-acf-field-intl-tel-input-v5.php
@@ -201,7 +201,7 @@ class jony_acf_field_intl_tel_input extends acf_field {
 		}
 		$attr = implode( ' ', $attr );
 		
-		?><input type="tel" value="<?php echo esc_attr($field['value']) ?>" <?php echo $attr; ?>><?php
+                ?><input type="tel" value="<?php echo esc_attr($field['value']) ?>" <?php echo $attr; ?> <?php echo $field['required'] ? 'required="required"' : ''; ?>><?php
 	}
 	
 		


### PR DESCRIPTION
The intl-tel field does not work in the Frontend with acf_form forms. I have initialized the field and assigned the value to the original Hidden field. Tested in Wordpress 4.9.8 and ACF Pro 5.7.7. 

In addition, the field did not add the required attribute.
