### PR TITLE
Returns `false` if the input field type is not appropriate.

### DIFF
--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -17,6 +17,8 @@
 	function initialize_field( $field ) {
 		// get input field
 		var $telInput = $field.find('input');
+		if ( $telInput.attr('type') != 'tel' )
+			return false;
 		// set telInput options
 		var $telInputOptions = {
        autoPlaceholder: "aggressive",


### PR DESCRIPTION
The script was trying to work with fields of type `hidden`, so a condition was added to check if the field in question is of the correct type.